### PR TITLE
Change resulting filesystem structure, moving everything in project dir.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
         <!-- to work around filtering bug, which makes maven.build.timestamp inaccessible -->
         <build.timestamp>${maven.build.timestamp}</build.timestamp>
-        <module.dependencies.path>..</module.dependencies.path>
+        <module.dependencies.path>.</module.dependencies.path>
     </properties>
 
     <dependencies>

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -15,6 +15,7 @@ root=$(dirname $(dirname $0))
 deproot=${1:-"${modulesPrefix}"}
 pom="$root/pom.xml"
 repos=$(grep '<!-- GIT ' $pom | sed -e 's/.*GIT \([^[:space:]]\{1,\}\).*/\1/g')
+gitignore="$root/.gitignore"
 
 for repo_and_tag in $repos; do
 	repo=$(echo $repo_and_tag | cut -d '=' -f 1)
@@ -32,6 +33,7 @@ for repo_and_tag in $repos; do
 	else
 		log "Cloning repository: $repo"
 		git clone $repo "$root/$deproot/$dir"
+		grep -q ${dir} ${gitignore} || printf "\n%s\n" "${dir}" >> ${gitignore}
 	fi
 
 	log "Checkout revision: $rev in $repo"

--- a/scripts/bootstrap-plugin
+++ b/scripts/bootstrap-plugin
@@ -7,7 +7,7 @@ prefix=$(dirname $0)
 check_for_server_dir
 
 pluginname=graylog-plugin-$1
-if [ -z $pluginname ]; then
+if [ -z $1 ]; then
   err "Syntax: $0 <plugin name>"
 fi
 
@@ -21,3 +21,8 @@ buildConf=${modulesDir}/${pluginname}/build.config.js
 cp ${buildConf}.sample ${buildConf}
 
 grep -q ${pluginname} ${gitignore} || printf "\n%s\n" "${pluginname}" >> ${gitignore}
+
+pushd 2> /dev/null
+cd $pluginname
+mvn generate-resources
+popd 2> /dev/null

--- a/scripts/bootstrap-plugin
+++ b/scripts/bootstrap-plugin
@@ -15,8 +15,6 @@ if [ -d $pluginname ]; then
   err "There is already a plugin with that name. Cowardly refusing to overwrite it."
 fi
 
-buildConfigFilename=${pluginname}/build.config.js
-
 mvn archetype:generate -DarchetypeGroupId=org.graylog -DarchetypeArtifactId=graylog-plugin-archetype -DartifactId=$pluginname
 
-sed 's,\(../graylog2-server/graylog2-web-interface\),../\1/,' < ${buildConfigFilename}.sample > ${buildConfigFilename}
+echo ${pluginname}/ >> ${prefix}/.gitignore

--- a/scripts/bootstrap-plugin
+++ b/scripts/bootstrap-plugin
@@ -20,7 +20,7 @@ mvn archetype:generate -DarchetypeGroupId=org.graylog -DarchetypeArtifactId=gray
 buildConf=${modulesPrefix}/${pluginname}/build.config.js
 cp ${buildConf}.sample ${buildConf}
 
-gitignore=${prefix}/.gitignore
+gitignore=${projectRoot}/.gitignore
 grep -q ${pluginname} ${gitignore} || printf "\n%s\n" "${pluginname}" >> ${gitignore}
 
 pushd 2> /dev/null

--- a/scripts/bootstrap-plugin
+++ b/scripts/bootstrap-plugin
@@ -20,6 +20,7 @@ mvn archetype:generate -DarchetypeGroupId=org.graylog -DarchetypeArtifactId=gray
 buildConf=${modulesPrefix}/${pluginname}/build.config.js
 cp ${buildConf}.sample ${buildConf}
 
+gitignore=${prefix}/.gitignore
 grep -q ${pluginname} ${gitignore} || printf "\n%s\n" "${pluginname}" >> ${gitignore}
 
 pushd 2> /dev/null

--- a/scripts/bootstrap-plugin
+++ b/scripts/bootstrap-plugin
@@ -6,7 +6,7 @@ prefix=$(dirname $0)
 
 check_for_server_dir
 
-pluginname=$1
+pluginname=graylog-plugin-$1
 if [ -z $pluginname ]; then
   err "Syntax: $0 <plugin name>"
 fi
@@ -17,4 +17,7 @@ fi
 
 mvn archetype:generate -DarchetypeGroupId=org.graylog -DarchetypeArtifactId=graylog-plugin-archetype -DartifactId=$pluginname
 
-echo ${pluginname}/ >> ${prefix}/.gitignore
+buildConf=${modulesDir}/${pluginname}/build.config.js
+cp ${buildConf}.sample ${buildConf}
+
+grep -q ${pluginname} ${gitignore} || printf "\n%s\n" "${pluginname}" >> ${gitignore}

--- a/scripts/bootstrap-plugin
+++ b/scripts/bootstrap-plugin
@@ -17,7 +17,7 @@ fi
 
 mvn archetype:generate -DarchetypeGroupId=org.graylog -DarchetypeArtifactId=graylog-plugin-archetype -DartifactId=$pluginname
 
-buildConf=${modulesDir}/${pluginname}/build.config.js
+buildConf=${modulesPrefix}/${pluginname}/build.config.js
 cp ${buildConf}.sample ${buildConf}
 
 grep -q ${pluginname} ${gitignore} || printf "\n%s\n" "${pluginname}" >> ${gitignore}

--- a/scripts/includes
+++ b/scripts/includes
@@ -4,7 +4,7 @@ err() {
 }
 
 prefix=$(dirname $0)
-modulesPrefix=..
+modulesPrefix=.
 serverDir=${modulesPrefix}/graylog2-server
 webIfDir=${serverDir}/graylog2-web-interface
 

--- a/scripts/includes
+++ b/scripts/includes
@@ -4,6 +4,7 @@ err() {
 }
 
 prefix=$(dirname $0)
+projectRoot=${prefix}/..
 modulesPrefix=.
 serverDir=${modulesPrefix}/graylog2-server
 webIfDir=${serverDir}/graylog2-web-interface


### PR DESCRIPTION
Instead of having/expecting project/server/plugin repos on the same level in the filesystem hierarchy, this PR is changing it so graylog-project dir contains all of the aforementioned. This makes it a bit less cluttered for developers because everything is under one directory.