### PR TITLE
Adding manifests for 3.1 & 3.1.2

### DIFF
--- a/manifests/3.1.2.json
+++ b/manifests/3.1.2.json
@@ -1,0 +1,32 @@
+{
+  "modules": [
+    {
+      "repository": "git@github.com:Graylog2/graylog2-server.git",
+      "revision": "3.1.2",
+      "server": true,
+      "submodules": [
+        {
+          "path": "graylog2-server"
+        },
+        {
+          "path": "graylog2-web-interface"
+        }
+      ]
+    },
+    {
+      "repository": "git@github.com:Graylog2/graylog-plugin-collector.git",
+      "revision": "3.1.2",
+      "assemblies": ["graylog"]
+    },
+    {
+      "repository": "git@github.com:Graylog2/graylog-plugin-aws.git",
+      "revision": "3.1.2",
+      "assemblies": ["graylog"]
+    },
+    {
+      "repository": "git@github.com:Graylog2/graylog-plugin-threatintel.git",
+      "revision": "3.1.2",
+      "assemblies": ["graylog"]
+    }
+  ]
+}

--- a/manifests/3.1.json
+++ b/manifests/3.1.json
@@ -1,0 +1,32 @@
+{
+  "modules": [
+    {
+      "repository": "git@github.com:Graylog2/graylog2-server.git",
+      "revision": "3.1",
+      "server": true,
+      "submodules": [
+        {
+          "path": "graylog2-server"
+        },
+        {
+          "path": "graylog2-web-interface"
+        }
+      ]
+    },
+    {
+      "repository": "git@github.com:Graylog2/graylog-plugin-collector.git",
+      "revision": "3.1",
+      "assemblies": ["graylog"]
+    },
+    {
+      "repository": "git@github.com:Graylog2/graylog-plugin-aws.git",
+      "revision": "3.1",
+      "assemblies": ["graylog"]
+    },
+    {
+      "repository": "git@github.com:Graylog2/graylog-plugin-threatintel.git",
+      "revision": "3.1",
+      "assemblies": ["graylog"]
+    }
+  ]
+}


### PR DESCRIPTION
This change is adding the missing manifest for 3.1. It also adds a manifest for `3.1.2`, so a plugin author can target a plugin against the latest released version instead of a branch which tracks the most recent snapshot for a (potentially) upcoming release.