### PR TITLE
fix: Development startup elasticsearch and java version

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ service running. If you're just testing this out and you don't care about persis
 ```
 sudo sysctl -w vm.max_map_count=262144
 docker run -d -p 27017:27017 --name mongo mongo:latest
-docker run -d -p 9200:9200 -p 9300:9300 elasticsearch:7.17.6
+docker run -d -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" elasticsearch:7.17.6
 ```
 
 Make sure that `graylog.conf` contains the correct connection details for Elasticsearch and MongoDB.

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ service running. If you're just testing this out and you don't care about persis
 ```
 sudo sysctl -w vm.max_map_count=262144
 docker run -d -p 27017:27017 --name mongo mongo:latest
-docker run -d -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" elasticsearch:7.17.6
+docker run -d -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" -e "action.auto_create_index=false" docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
 ```
 
 Make sure that `graylog.conf` contains the correct connection details for Elasticsearch and MongoDB.

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ service running. If you're just testing this out and you don't care about persis
 ```
 sudo sysctl -w vm.max_map_count=262144
 docker run -d -p 27017:27017 --name mongo mongo:latest
-docker run -d -p 9200:9200 -p 9300:9300 elasticsearch:7.10.2
+docker run -d -p 9200:9200 -p 9300:9300 elasticsearch:7.17.6
 ```
 
 Make sure that `graylog.conf` contains the correct connection details for Elasticsearch and MongoDB.

--- a/runner/docker/images/dev-server-runner/Dockerfile
+++ b/runner/docker/images/dev-server-runner/Dockerfile
@@ -9,7 +9,7 @@ RUN curl -sL -o /usr/bin/graylog-project https://github.com/Graylog2/graylog-pro
 
 
 # Final layer
-FROM maven:3.6-jdk-8
+FROM maven:3.6-openjdk-17
 
 COPY --from=build /usr/sbin/gosu /usr/sbin/gosu
 COPY --from=build /usr/bin/uuidgen /usr/bin/uuidgen


### PR DESCRIPTION
```
docker pull elasticsearch:7.10.2

Error response from daemon: manifest for elasticsearch:7.10.2 not found: manifest unknown: manifest unknown

```

## Notes for Reviewers

- [x] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [x] Sync up with the author before merging

